### PR TITLE
Fix - 채팅 이슈 해결 시도

### DIFF
--- a/public/script/chat.js
+++ b/public/script/chat.js
@@ -8,9 +8,9 @@ const socket = io({
     reconnectionAttempts: Infinity, // 재연결 시도 횟수 (무한)
     reconnectionDelay: 1000, // 초기 재연결 지연 시간 (밀리초)
     reconnectionDelayMax: 5000, // 최대 재연결 지연 시간 (밀리초)
-    pingInterval: 60000, // 60초마다 ping
-    pingTimeout: 60000, // 60초 동안 응답 없으면 연결 종료
-    upgradeTimeout: 60000, // 연결 업그레이드 시간 제한
+    //pingInterval: 60000, // 60초마다 ping
+    //pingTimeout: 60000, // 60초 동안 응답 없으면 연결 종료
+    //upgradeTimeout: 60000, // 연결 업그레이드 시간 제한
 });
 
 console.log('path확인', path);

--- a/src/chat/chat.disconnect.ts
+++ b/src/chat/chat.disconnect.ts
@@ -30,7 +30,7 @@ export class ChatGatewayDisconnect implements OnGatewayDisconnect {
     async handleDisconnect(client: Socket) {
         try {
             const reason = client.disconnect; // Socket.IO 3.x 이상에서 사용 가능
-            console.log('reason', reason);
+            Logger.log('reason', reason);
             Logger.log('___________________________', client);
 
             Logger.log(`클라이언트 아이디에요 확인필수: ${client.id}`);


### PR DESCRIPTION
## 채팅을 동시에 입력시 한명이 전송하면 모든 입력값이 사라지는 현상
- chatInputText.value='' 의 위치 조정하여 해결


## 새로고침 할때 채팅 데이터 못불러 오던 현상
- 기존 : 테스트 할때 추가했던 userDisconnectData 로 반복문 돌림
- 변경 : 레디스에서 꺼내온 채팅 데이터 getAllChatData 로 반복문 돌림으로 해결


## 채팅이 지속적으로 disconnect 되는 현상
- 클라이언트 쪽 코드에서 pingInterval 추가.
- docker , GCP 환경에서 정상 작동 확인
- 쿠버네티스 환경 여전히 끊김 --> 아직 조정 필요.